### PR TITLE
Automatically choose best tqdm

### DIFF
--- a/torchpack/callbacks/inference.py
+++ b/torchpack/callbacks/inference.py
@@ -2,7 +2,7 @@ import time
 from typing import List
 
 import torch
-import tqdm
+from tqdm.auto import tqdm
 from torch.utils.data import DataLoader
 
 from torchpack.callbacks.callback import Callback, Callbacks
@@ -33,7 +33,7 @@ class InferenceRunner(Callback):
         self.callbacks.before_epoch()
 
         with torch.no_grad():
-            for feed_dict in tqdm.tqdm(self.dataflow, ncols=0):
+            for feed_dict in tqdm(self.dataflow, ncols=0):
                 self.callbacks.before_step(feed_dict)
                 output_dict = self.trainer.run_step(feed_dict)
                 self.callbacks.after_step(output_dict)

--- a/torchpack/callbacks/progress.py
+++ b/torchpack/callbacks/progress.py
@@ -3,7 +3,7 @@ from collections import deque
 from typing import List, Union
 
 import numpy as np
-import tqdm
+from tqdm.auto import tqdm
 
 from torchpack.callbacks.callback import Callback
 from torchpack.utils import humanize
@@ -23,7 +23,7 @@ class ProgressBar(Callback):
         self.matcher = NameMatcher(patterns=scalars)
 
     def _before_epoch(self) -> None:
-        self.pbar = tqdm.trange(self.trainer.steps_per_epoch, ncols=0)
+        self.pbar = tqdm(range(self.trainer.steps_per_epoch), ncols=0)
 
     def _trigger_step(self) -> None:
         texts = []


### PR DESCRIPTION
Switch to tqdm.auto to enable better progress bars in jupyter notebooks vs terminal.