### PR TITLE
Fall back to normal 

### DIFF
--- a/torchpack/distributed/context.py
+++ b/torchpack/distributed/context.py
@@ -20,12 +20,15 @@ def init(backend: int = 'nccl',
     _world_size, _world_rank = world_comm.Get_size(), world_comm.Get_rank()
     _local_size, _local_rank = local_comm.Get_size(), local_comm.Get_rank()
 
-    master_host = 'tcp://' + os.environ['MASTER_HOST']
-    torch.distributed.init_process_group(backend=backend,
-                                         init_method=master_host,
-                                         timeout=timeout,
-                                         world_size=_world_size,
-                                         rank=_world_rank)
+    if 'MASTER_HOST' in os.environ:
+        master_host = 'tcp://' + os.environ['MASTER_HOST']
+        torch.distributed.init_process_group(backend=backend,
+                                             init_method=master_host,
+                                             timeout=timeout,
+                                             world_size=_world_size,
+                                             rank=_world_rank)
+    else:
+        print("Distributed environment not detected, fall back to default")
 
 
 def size() -> int:


### PR DESCRIPTION
This modification enables horovod-like behavior, that a script can be run both with and without the `torchpack` prefix.

If a script can be ran by `torchpack dist-run -np X python script.py`, now it can also be ran by `python script.py` without raising KeyError.

**Advantage**: we can now set breakpoints like `IPython.embed()` or `ipdb.set_trace()` in the script and call the script without incurring torchpack. In the torchpack environment, certain keys won't be passed into the interactive job, which makes debugging difficult.