### PR TITLE
dummy master_host in distributed.init()

### DIFF
--- a/torchpack/distributed/context.py
+++ b/torchpack/distributed/context.py
@@ -22,13 +22,15 @@ def init(backend: int = 'nccl',
 
     if 'MASTER_HOST' in os.environ:
         master_host = 'tcp://' + os.environ['MASTER_HOST']
-        torch.distributed.init_process_group(backend=backend,
-                                             init_method=master_host,
-                                             timeout=timeout,
-                                             world_size=_world_size,
-                                             rank=_world_rank)
     else:
+        from torchpack.launch.launchers.drunner import get_free_tcp_port
+        master_host = 'tcp://localhost:{}'.format(get_free_tcp_port())
         print("Distributed environment not detected, fall back to default")
+    torch.distributed.init_process_group(backend=backend,
+                                         init_method=master_host,
+                                         timeout=timeout,
+                                         world_size=_world_size,
+                                         rank=_world_rank)
 
 
 def size() -> int:


### PR DESCRIPTION
PR [19](https://github.com/zhijian-liu/torchpack/pull/19) has the issue when actually calling the DistributedDataParallel module.  Calling `torch.distributed.init_process_group` with a dummy master_host can solve this issue.